### PR TITLE
HTML Entities: Encode them

### DIFF
--- a/docs/02-customize-a-pizza.md
+++ b/docs/02-customize-a-pizza.md
@@ -91,7 +91,7 @@ Add the following basic markup for the `ConfigurePizzaDialog`:
             <span class="mr-center">
                 Price: <span class="price">@(Pizza.GetFormattedTotalPrice())</span>
             </span>
-            <button class="btn btn-success ml-auto">Order ></button>
+            <button class="btn btn-success ml-auto">Order &gt;</button>
         </div>
     </div>
 </div>
@@ -122,7 +122,7 @@ The user should be able to specify the size of their pizza. Add markup to the bo
         <label>Size:</label>
         <input type="range" min="@Pizza.MinimumSize" max="@Pizza.MaximumSize" step="1" />
         <span class="size-label">
-            @(Pizza.Size)" (£@(Pizza.GetFormattedTotalPrice()))
+            @(Pizza.Size)" (@(Pizza.GetFormattedTotalPrice()))
         </span>
     </div>
 </form>
@@ -210,7 +210,7 @@ Add the following markup in the dialog body for displaying a drop down list with
             <option value="-1" disabled selected>(select)</option>
             @for (var i = 0; i < toppings.Count; i++)
             {
-                <option value="@i">@toppings[i].Name - (£@(toppings[i].GetFormattedPrice()))</option>
+                <option value="@i">@toppings[i].Name - (&pound;@(toppings[i].GetFormattedPrice()))</option>
             }
         </select>
     }
@@ -277,7 +277,7 @@ Add `@onclick` event handlers to the `ConfigurePizzaDialog` that trigger the `On
     <span class="mr-center">
         Price: <span class="price">@(Pizza.GetFormattedTotalPrice())</span>
     </span>
-    <button class="btn btn-success ml-auto" @onclick="@OnConfirm">Order ></button>
+    <button class="btn btn-success ml-auto" @onclick="@OnConfirm">Order &gt;</button>
 </div>
 ```
 
@@ -384,7 +384,7 @@ Add the following markup to the `Index` component just below the main `div` to a
         Total:
         <span class="total-price">@order.GetFormattedTotalPrice()</span>
         <button class="btn btn-warning" disabled="@(order.Pizzas.Count == 0)" @onclick="@PlaceOrder">
-            Order >
+            Order &gt;
         </button>
     </div>
 </div>

--- a/docs/03-show-order-status.md
+++ b/docs/03-show-order-status.md
@@ -169,7 +169,7 @@ Replace the `<text>TODO: show orders</text>` code with the following:
                 Items:
                 <strong>@item.Order.Pizzas.Count()</strong>;
                 Total price:
-                <strong>£@item.Order.GetFormattedTotalPrice()</strong>
+                <strong>&pound;@item.Order.GetFormattedTotalPrice()</strong>
             </div>
             <div class="col">
                 Status: <strong>@item.StatusText</strong>
@@ -343,7 +343,7 @@ Create a new file, `OrderReview.razor` inside the `Shared` directory, and have i
         <strong>
             @(pizza.Size)"
             @pizza.Special.Name
-            (£@pizza.GetFormattedTotalPrice())
+            (&pound;@pizza.GetFormattedTotalPrice())
         </strong>
     </p>
 
@@ -358,7 +358,7 @@ Create a new file, `OrderReview.razor` inside the `Shared` directory, and have i
 <p>
     <strong>
         Total price:
-        £@Order.GetFormattedTotalPrice()
+        &pound;@Order.GetFormattedTotalPrice()
     </strong>
 </p>
 

--- a/docs/05-checkout-with-validation.md
+++ b/docs/05-checkout-with-validation.md
@@ -42,7 +42,7 @@ Next, let's bring customers here when they try to submit orders. Back in `Index.
 
 ```html
 <a href="checkout" class="btn btn-warning" disabled="@(OrderState.Order.Pizzas.Count == 0)">
-    Order >
+    Order &gt;
 </a>
 ```
 

--- a/docs/08-templated-components.md
+++ b/docs/08-templated-components.md
@@ -436,7 +436,7 @@ Now we want to include all of the existing content from `MyOrders.razor`, so put
                 Items:
                 <strong>@item.Order.Pizzas.Count()</strong>;
                 Total price:
-                <strong>£@item.Order.GetFormattedTotalPrice()</strong>
+                <strong>&pound;@item.Order.GetFormattedTotalPrice()</strong>
             </div>
             <div class="col">
                 Status: <strong>@item.StatusText</strong>


### PR DESCRIPTION
This changes `>` to `&gt;` and `£` to `&pound;` which was inconsistent in the examples and caused some unnecessary pain in the workshop. No big changes, just a tidy item!